### PR TITLE
Support for floating-point operations

### DIFF
--- a/mips.JSON-tmLanguage
+++ b/mips.JSON-tmLanguage
@@ -18,6 +18,11 @@
         "comment": "Registers by id $1, $2, ..."
     },
     {
+        "match": "\\$f([0-9]|[1-2][0-9]|3[0-1])",
+        "name": "variable.parameter.mips",
+        "comment": "Floating point registers"
+    },
+    {
         "match": "\\b((add|sub|div|l|mov|mul|neg|s|c\\.eq|c\\.le|c\\.lt)\\.[ds]|cvt\\.s\\.[dw]|cvt\\.d\\.[sw]|cvt\\.w\\.[ds]|bc1[tf])\\b",
         "name": "support.function.source.mips",
         "comment": "The MIPS floating-point instruction set"

--- a/mips.tmLanguage
+++ b/mips.tmLanguage
@@ -37,6 +37,14 @@
 		</dict>
 		<dict>
 			<key>comment</key>
+			<string>Floating point registers</string>
+			<key>match</key>
+			<string>\$f([0-9]|[1-2][0-9]|3[0-1])</string>
+			<key>name</key>
+			<string>variable.parameter.mips</string>
+		</dict>
+		<dict>
+			<key>comment</key>
 			<string>The MIPS floating-point instruction set</string>
 			<key>match</key>
 			<string>\b((add|sub|div|l|mov|mul|neg|s|c\.eq|c\.le|c\.lt)\.[ds]|cvt\.s\.[dw]|cvt\.d\.[sw]|cvt\.w\.[ds]|bc1[tf])\b</string>


### PR DESCRIPTION
This pull request adds syntax highlighting for floating point instructions and registers. (See http://www.doc.ic.ac.uk/lab/secondyear/spim/node20.html)
